### PR TITLE
Redo error parsing

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -4,21 +4,15 @@ from SublimeLinter.lint import PythonLinter
 class Pyflakes(PythonLinter):
     cmd = 'pyflakes'
     regex = r'''(?x)
-        .+?:\s*               # filename
-        (?P<line>\d+):\s*     # line number
+        ^(?P<filename>[^:\n]+):(?P<line>\d+):((?P<col>\d+):)?\s
 
         # The rest of the line is the error message.
-        # Within that, capture anything within single quotes as 'near'.
-        (?P<message>[^\'\n\r]+(?P<near>\'.+?\')?.*)
-
-        # The error message may be followed by the offending line of code...
-        (?:\r?\n.*
-
-        # and then another line with a caret (preceded by spaces)
-        # pointing to the position where the error occurred.
-        \r?\n(?P<col>[ ]+)\^)?
+        # Within that, capture anything within single quotes as `near`.
+        (?P<message>[^\'\n\r]*(?P<near>\'.+?\')?.*)
     '''
     multiline = True
+    # stderr has all syntax errors, parse it via our regex
+    on_stderr = None
     defaults = {
         'selector': 'source.python'
     }


### PR DESCRIPTION
Fixes https://github.com/SublimeLinter/SublimeLinter/issues/1384

`pyflakes` outputs parsing errors on stderr, so we opt out of automatic
`on_stderr` handling.

Otherwise, we capture `<col>` if present.