### PR TITLE
Fix regex for pyflakes output format since `2.2.0`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -5,7 +5,7 @@ import re
 class Pyflakes(PythonLinter):
     cmd = 'pyflakes'
     regex = r'''(?x)
-        ^(?P<filename>[^:\n]+):(?P<line>\d+):((?P<col>\d+):)?\s
+        ^(?P<filename>.+):(?P<line>\d+):((?P<col>\d+):?)?\s
 
         # The rest of the line is the error message.
         # Within that, capture anything within single quotes as `near`.


### PR DESCRIPTION
Beginning with version `2.2.0` pyflakes will not put a `:` at the end of the column.  Actually, I think `pyflakes` never had any col info before but who knows that.  Also the capturing part for `<filename>` with its `\n` looks rather funny; I just omit this. 

Fixes #15 